### PR TITLE
don't write to a temp url if it's already a local file url

### DIFF
--- a/src/ios/PhotoViewer.m
+++ b/src/ios/PhotoViewer.m
@@ -89,6 +89,9 @@
     NSURL *tmpDirURL = [NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES];
     NSString *filename = [[NSUUID UUID] UUIDString];
     NSURL *fileURL = [NSURL URLWithString:image];
+    if ([fileURL isFileReferenceURL]) {
+        return fileURL;
+    }
 
     NSData *data = [NSData dataWithContentsOfURL:fileURL];
 


### PR DESCRIPTION
My Cordova app is already doing image caching for a number of things, so this patch makes it so PhotoViewer doesn't create a temp file for an already local URL.