### PR TITLE
Added support for base64-encoded images

### DIFF
--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -3,10 +3,12 @@ package com.sarriaroman.PhotoViewer;
 import uk.co.senab.photoview.PhotoViewAttacher;
 import android.app.Activity;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Environment;
+import android.util.Base64;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -137,11 +139,18 @@ public class PhotoActivity extends Activity {
 						finish();
 					}
 				});
-		} else {
-			photo.setImageURI(Uri.parse(imageUrl));
+	} else if ( imageUrl.startsWith("data:image")){
+            String base64String = imageUrl.substring(imageUrl.indexOf(",")+1);
+            byte[] decodedString = Base64.decode(base64String, Base64.DEFAULT);
+            Bitmap decodedByte = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
+            photo.setImageBitmap(decodedByte);
 
-			hideLoadingAndUpdate();
-		}
+            hideLoadingAndUpdate();
+        } else {
+            photo.setImageURI(Uri.parse(imageUrl));
+
+            hideLoadingAndUpdate();
+        }
 	}
 
 	/**


### PR DESCRIPTION
Added support for opening images directly as a base64-encoded string. This already worked in iOS, but threw an 'invalid URL'-error on Android.