### PR TITLE
added runtime permission handling

### DIFF
--- a/src/android/PhotoViewer.java
+++ b/src/android/PhotoViewer.java
@@ -37,7 +37,7 @@ public class PhotoViewer extends CordovaPlugin {
             if (cordova.hasPermission(READ) && cordova.hasPermission(WRITE)) {
                 this.launchActivity();
             } else {
-                getPermission();
+                this.getPermission();
             }
             return true;
         }

--- a/src/android/PhotoViewer.java
+++ b/src/android/PhotoViewer.java
@@ -2,10 +2,13 @@ package com.sarriaroman.PhotoViewer;
 
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
+import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 
 /**
  * Class to Open PhotoViewer with the Required Parameters from Cordova
@@ -15,22 +18,62 @@ import android.content.Intent;
  */
 public class PhotoViewer extends CordovaPlugin {
 
+    public static final int PERMISSION_DENIED_ERROR = 20;
+
+    public static final String WRITE = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+    public static final String READ = Manifest.permission.READ_EXTERNAL_STORAGE;
+
+    public static final int REQ_CODE = 0;
+
+    protected JSONArray args;
+    protected CallbackContext callbackContext;
+
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         if (action.equals("show")) {
+            this.args = args;
+            this.callbackContext = callbackContext;
 
-			Intent i = new Intent(this.cordova.getActivity(), com.sarriaroman.PhotoViewer.PhotoActivity.class);
-
-			i.putExtra("url", args.getString(0));
-            i.putExtra("title", args.getString(1));
-            i.putExtra("options", args.optJSONObject(2).toString());
-
-			this.cordova.getActivity().startActivity(i);
-
-			callbackContext.success("");
-
+            if (cordova.hasPermission(READ) && cordova.hasPermission(WRITE)) {
+                this.launchActivity();
+            } else {
+                getPermission();
+            }
             return true;
         }
         return false;
+    }
+
+    protected void getPermission() {
+        cordova.requestPermissions(this, REQ_CODE, new String[]{WRITE, READ});
+    }
+
+    protected void launchActivity() throws JSONException {
+        Intent i = new Intent(this.cordova.getActivity(), com.sarriaroman.PhotoViewer.PhotoActivity.class);
+
+        i.putExtra("url", this.args.getString(0));
+        i.putExtra("title", this.args.getString(1));
+        i.putExtra("options", this.args.optJSONObject(2).toString());
+
+        this.cordova.getActivity().startActivity(i);
+        this.callbackContext.success("");
+    }
+
+    @Override
+    public void onRequestPermissionResult(int requestCode, String[] permissions,
+                                          int[] grantResults) throws JSONException {
+        for(int r:grantResults) {
+            if(r == PackageManager.PERMISSION_DENIED) {
+                this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, PERMISSION_DENIED_ERROR));
+                return;
+            }
+        }
+
+        switch(requestCode) {
+            case REQ_CODE:
+                launchActivity();
+                break;
+        }
+
     }
 }


### PR DESCRIPTION
Just let Cordova do all the heavy lifting so you don't have to rewrite it all in the Activity. Of course READ permission isn't really necessary if the developer disables the 'share' button. 