### PR TITLE
Preserve the aspect ration of images

### DIFF
--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -138,7 +138,6 @@ public class PhotoActivity extends Activity {
 		if( imageUrl.startsWith("http") ) {
 		Picasso.with(this)
 				.load(imageUrl)
-				.fit()
 				.into(photo, new com.squareup.picasso.Callback() {
 					@Override
 					public void onSuccess() {


### PR DESCRIPTION
Reverted a line that was causing the photo viewer to stretch images.
Fixes Issue #41 