### PR TITLE
Changed adjusting photo to ImageView

### DIFF
--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -138,7 +138,7 @@ public class PhotoActivity extends Activity {
 		if( imageUrl.startsWith("http") ) {
 		Picasso.with(this)
 				.load(imageUrl)
-				.fit()
+				.centerInside()
 				.into(photo, new com.squareup.picasso.Callback() {
 					@Override
 					public void onSuccess() {

--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -138,6 +138,7 @@ public class PhotoActivity extends Activity {
 		if( imageUrl.startsWith("http") ) {
 		Picasso.with(this)
 				.load(imageUrl)
+				.fit()
 				.centerInside()
 				.into(photo, new com.squareup.picasso.Callback() {
 					@Override


### PR DESCRIPTION
Combined fit() method with centerInside(), because of problem with scale. When proportions of the photo are different than ImageView's, photo is distorted while using only fit() method.  When we use fit() combined with centerInside() it is scalled down in case of huge images and then adjusted to at least one ImageView's dimension and it keeps the photo ratio.