### PR TITLE
fixed java.lang.OutOfMemoryError during open local URI:

### DIFF
--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -135,7 +135,7 @@ public class PhotoActivity extends Activity {
 	 *
 	 */
 	private void loadImage() {
-		if( imageUrl.startsWith("http") ) {
+		if( imageUrl.startsWith("http") || imageUrl.startsWith("file") ) {
 		Picasso.with(this)
 				.load(imageUrl)
 				.fit()


### PR DESCRIPTION
02-03 15:10:50.836: E/AndroidRuntime(32577): java.lang.OutOfMemoryError
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at android.graphics.BitmapFactory.nativeDecodeStream(Native Method)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at android.graphics.BitmapFactory.decodeStreamInternal(BitmapFactory.java:613)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at android.graphics.BitmapFactory.decodeStream(BitmapFactory.java:589)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at android.graphics.BitmapFactory.decodeResourceStream(BitmapFactory.java:422)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at android.graphics.drawable.Drawable.createFromResourceStream(Drawable.java:840)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at android.graphics.drawable.Drawable.createFromStream(Drawable.java:791)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at android.widget.ImageView.resolveUri(ImageView.java:660)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at android.widget.ImageView.setImageURI(ImageView.java:399)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at com.sarriaroman.PhotoViewer.PhotoActivity.loadImage(PhotoActivity.java:164)
02-03 15:10:50.836: E/AndroidRuntime(32577): 	at com.sarriaroman.PhotoViewer.PhotoActivity.onCreate(PhotoActivity.java:93)