### PR TITLE
Added BMP support for iOS

### DIFF
--- a/src/ios/PhotoViewer.m
+++ b/src/ios/PhotoViewer.m
@@ -117,6 +117,8 @@
             return @"png";
         case 0x47:
             return @"gif";
+        case 0x42:
+            return @"bmp";
         case 0x49:
         case 0x4D:
             return @"tiff";


### PR DESCRIPTION
I added the `BMP` file signature for `iOS`. Without this file signature, attempting to open a `BMP` file results in a `nil` return, and subsequently `SIGABRT`, crashing the application.