### PR TITLE
Fix transaction too large

### DIFF
--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -6,6 +6,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.util.Base64;
@@ -15,32 +16,39 @@ import android.widget.ImageView;
 
 import android.content.Intent;
 import android.net.Uri;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import com.squareup.picasso.Picasso;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Random;
 
 public class PhotoActivity extends Activity {
 	private PhotoViewAttacher mAttacher;
 
 	private ImageView photo;
-	private String imageUrl;
 
 	private ImageButton closeBtn;
 	private ImageButton shareBtn;
+	private ProgressBar loadingBar;
 
 	private TextView titleTxt;
 
-	private JSONObject options;
+    private String mImage;
+    private String mTitle;
+    private JSONObject mOptions;
+	private File mTempImage;
 	private int shareBtnVisibility;
 
+    public static JSONArray mArgs = null;
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -51,20 +59,23 @@ public class PhotoActivity extends Activity {
 		findViews();
 
 		try {
-			options = new JSONObject(this.getIntent().getStringExtra("options"));
-			shareBtnVisibility = options.getBoolean("share") ? View.VISIBLE : View.INVISIBLE;
+            this.mImage = mArgs.getString(0);
+            this.mTitle = mArgs.getString(1);
+            this.mOptions = mArgs.getJSONObject(2);
+            //Set the share button visibility
+            shareBtnVisibility = mOptions.getBoolean("share") ? View.VISIBLE : View.INVISIBLE;
+
+
 		} catch(JSONException exception) {
 			shareBtnVisibility = View.VISIBLE;
 		}
 		shareBtn.setVisibility(shareBtnVisibility);
+        //Change the activity title
+        if (!mTitle.equals("")){
+            titleTxt.setText(mTitle);
+        }
 
-		// Change the Activity Title
-		String actTitle = this.getIntent().getStringExtra("title");
-		if( !actTitle.equals("") ) {
-			titleTxt.setText(actTitle);
-		}
-
-		imageUrl = this.getIntent().getStringExtra("url");
+        loadImage();
 
 		// Set Button Listeners
 		closeBtn.setOnClickListener(new View.OnClickListener() {
@@ -77,20 +88,25 @@ public class PhotoActivity extends Activity {
 		shareBtn.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				Uri bmpUri = getLocalBitmapUri(photo);
+				Uri imageUri = null;
+				if (mTempImage != null){
+					imageUri = Uri.fromFile(mTempImage);
+				}
+				else{
+					imageUri = getLocalBitmapUri(photo);
+				}
 
-				if (bmpUri != null) {
+				if (imageUri != null) {
 				    Intent sharingIntent = new Intent(Intent.ACTION_SEND);
 
 				    sharingIntent.setType("image/*");
-				    sharingIntent.putExtra(Intent.EXTRA_STREAM, bmpUri);
+				    sharingIntent.putExtra(Intent.EXTRA_STREAM, imageUri);
 
 				    startActivity(Intent.createChooser(sharingIntent, "Share"));
 				}
 			}
 		});
 
-		loadImage();
 	}
 
 	/**
@@ -102,6 +118,8 @@ public class PhotoActivity extends Activity {
 		closeBtn = (ImageButton) findViewById( getApplication().getResources().getIdentifier("closeBtn", "id", getApplication().getPackageName()) );
 		shareBtn = (ImageButton) findViewById( getApplication().getResources().getIdentifier("shareBtn", "id", getApplication().getPackageName()) );
 
+		//ProgressBar
+		loadingBar = (ProgressBar) findViewById(getApplication().getResources().getIdentifier("loadingBar", "id", getApplication().getPackageName()));
 		// Photo Container
 		photo = (ImageView) findViewById( getApplication().getResources().getIdentifier("photoView", "id", getApplication().getPackageName()) );
 		mAttacher = new PhotoViewAttacher(photo);
@@ -124,7 +142,7 @@ public class PhotoActivity extends Activity {
 	 */
 	private void hideLoadingAndUpdate() {
 		photo.setVisibility(View.VISIBLE);
-
+		loadingBar.setVisibility(View.INVISIBLE);
         shareBtn.setVisibility(shareBtnVisibility);
 
 		mAttacher.update();
@@ -135,36 +153,85 @@ public class PhotoActivity extends Activity {
 	 *
 	 */
 	private void loadImage() {
-		if( imageUrl.startsWith("http") || imageUrl.startsWith("file") ) {
-		Picasso.with(this)
-				.load(imageUrl)
-				.fit()
-				.centerInside()
-				.into(photo, new com.squareup.picasso.Callback() {
-					@Override
-					public void onSuccess() {
-						hideLoadingAndUpdate();
+		if( mImage.startsWith("http") || mImage.startsWith("file") ) {
+			Picasso.with(this)
+					.load(mImage)
+					.fit()
+					.centerInside()
+					.into(photo, new com.squareup.picasso.Callback() {
+						@Override
+						public void onSuccess() {
+							hideLoadingAndUpdate();
+						}
+
+						@Override
+						public void onError() {
+							Toast.makeText(getActivity(), "Error loading image.", Toast.LENGTH_LONG).show();
+
+							finish();
+						}
+					});
+		} else if ( mImage.startsWith("data:image")){
+
+			new AsyncTask<Void, Void, File>(){
+
+				protected File doInBackground(Void ...params){
+					String base64Image = mImage.substring(mImage.indexOf(",") + 1);
+					File file = null;
+					try{
+						file = getLocalBitmapFile(base64Image);
 					}
-
-					@Override
-					public void onError() {
-						Toast.makeText(getActivity(), "Error loading image.", Toast.LENGTH_LONG).show();
-
-						finish();
+					catch (IOException e){
+						e.printStackTrace();
 					}
-				});
-	} else if ( imageUrl.startsWith("data:image")){
-            String base64String = imageUrl.substring(imageUrl.indexOf(",")+1);
-            byte[] decodedString = Base64.decode(base64String, Base64.DEFAULT);
-            Bitmap decodedByte = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
-            photo.setImageBitmap(decodedByte);
+					return file;
+				}
 
-            hideLoadingAndUpdate();
+				protected void onPostExecute(File file){
+					mTempImage = file;
+					Picasso.with(PhotoActivity.this)
+						.load(mTempImage)
+						.fit()
+						.centerCrop()
+						.into(photo, new com.squareup.picasso.Callback(){
+							@Override
+							public void onSuccess() {
+								hideLoadingAndUpdate();
+							}
+
+							@Override
+							public void onError() {
+								Toast.makeText(getActivity(), "Error loading image.", Toast.LENGTH_LONG).show();
+
+								finish();
+							}
+						});
+				}
+			}.execute();
+
         } else {
-            photo.setImageURI(Uri.parse(imageUrl));
+            photo.setImageURI(Uri.parse(mImage));
 
             hideLoadingAndUpdate();
         }
+	}
+
+	public void onDestroy(){
+		if (mTempImage != null){
+			mTempImage.delete();
+		}
+		super.onDestroy();
+	}
+
+
+	public File getLocalBitmapFile(String base64) throws IOException{
+		byte []decoded = Base64.decode(base64, Base64.DEFAULT);
+		File file = new File(this.getCacheDir(), "temp_image_" + System.currentTimeMillis() + ".png");
+		file.getParentFile().mkdirs();
+		FileOutputStream output = new FileOutputStream(file);
+		output.write(decoded);
+		output.close();
+		return file;
 	}
 
 	/**

--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -1,9 +1,9 @@
 package com.sarriaroman.PhotoViewer;
 
 import uk.co.senab.photoview.PhotoViewAttacher;
+
 import android.app.Activity;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
@@ -29,36 +29,36 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.Random;
 
 public class PhotoActivity extends Activity {
-	private PhotoViewAttacher mAttacher;
+    private PhotoViewAttacher mAttacher;
 
-	private ImageView photo;
+    private ImageView photo;
 
-	private ImageButton closeBtn;
-	private ImageButton shareBtn;
-	private ProgressBar loadingBar;
+    private ImageButton closeBtn;
+    private ImageButton shareBtn;
+    private ProgressBar loadingBar;
 
-	private TextView titleTxt;
+    private TextView titleTxt;
 
     private String mImage;
     private String mTitle;
     private JSONObject mOptions;
-	private File mTempImage;
-	private int shareBtnVisibility;
+    private File mTempImage;
+    private int shareBtnVisibility;
 
     public static JSONArray mArgs = null;
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
 
-		setContentView(getApplication().getResources().getIdentifier("activity_photo", "layout", getApplication().getPackageName()));
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
-		// Load the Views
-		findViews();
+        setContentView(getApplication().getResources().getIdentifier("activity_photo", "layout", getApplication().getPackageName()));
 
-		try {
+        // Load the Views
+        findViews();
+
+        try {
             this.mImage = mArgs.getString(0);
             this.mTitle = mArgs.getString(1);
             this.mOptions = mArgs.getJSONObject(2);
@@ -66,210 +66,202 @@ public class PhotoActivity extends Activity {
             shareBtnVisibility = mOptions.getBoolean("share") ? View.VISIBLE : View.INVISIBLE;
 
 
-		} catch(JSONException exception) {
-			shareBtnVisibility = View.VISIBLE;
-		}
-		shareBtn.setVisibility(shareBtnVisibility);
+        } catch (JSONException exception) {
+            shareBtnVisibility = View.VISIBLE;
+        }
+        shareBtn.setVisibility(shareBtnVisibility);
         //Change the activity title
-        if (!mTitle.equals("")){
+        if (!mTitle.equals("")) {
             titleTxt.setText(mTitle);
         }
 
         loadImage();
 
-		// Set Button Listeners
-		closeBtn.setOnClickListener(new View.OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				finish();
-			}
-		});
+        // Set Button Listeners
+        closeBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
 
-		shareBtn.setOnClickListener(new View.OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				Uri imageUri = null;
-				if (mTempImage != null){
-					imageUri = Uri.fromFile(mTempImage);
-				}
-				else{
-					imageUri = getLocalBitmapUri(photo);
-				}
+        shareBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Uri imageUri;
+                if (mTempImage == null){
+                    mTempImage = getLocalBitmapFileFromView(photo);
+                }
 
-				if (imageUri != null) {
-				    Intent sharingIntent = new Intent(Intent.ACTION_SEND);
+                imageUri = Uri.fromFile(mTempImage);
 
-				    sharingIntent.setType("image/*");
-				    sharingIntent.putExtra(Intent.EXTRA_STREAM, imageUri);
+                if (imageUri != null) {
+                    Intent sharingIntent = new Intent(Intent.ACTION_SEND);
 
-				    startActivity(Intent.createChooser(sharingIntent, "Share"));
-				}
-			}
-		});
+                    sharingIntent.setType("image/*");
+                    sharingIntent.putExtra(Intent.EXTRA_STREAM, imageUri);
 
-	}
+                    startActivity(Intent.createChooser(sharingIntent, "Share"));
+                }
+            }
+        });
 
-	/**
-	 * Find and Connect Views
-	 *
-	 */
-	private void findViews() {
-		// Buttons first
-		closeBtn = (ImageButton) findViewById( getApplication().getResources().getIdentifier("closeBtn", "id", getApplication().getPackageName()) );
-		shareBtn = (ImageButton) findViewById( getApplication().getResources().getIdentifier("shareBtn", "id", getApplication().getPackageName()) );
+    }
 
-		//ProgressBar
-		loadingBar = (ProgressBar) findViewById(getApplication().getResources().getIdentifier("loadingBar", "id", getApplication().getPackageName()));
-		// Photo Container
-		photo = (ImageView) findViewById( getApplication().getResources().getIdentifier("photoView", "id", getApplication().getPackageName()) );
-		mAttacher = new PhotoViewAttacher(photo);
+    /**
+     * Find and Connect Views
+     */
+    private void findViews() {
+        // Buttons first
+        closeBtn = (ImageButton) findViewById(getApplication().getResources().getIdentifier("closeBtn", "id", getApplication().getPackageName()));
+        shareBtn = (ImageButton) findViewById(getApplication().getResources().getIdentifier("shareBtn", "id", getApplication().getPackageName()));
 
-		// Title TextView
-		titleTxt = (TextView) findViewById( getApplication().getResources().getIdentifier("titleTxt", "id", getApplication().getPackageName()) );
-	}
+        //ProgressBar
+        loadingBar = (ProgressBar) findViewById(getApplication().getResources().getIdentifier("loadingBar", "id", getApplication().getPackageName()));
+        // Photo Container
+        photo = (ImageView) findViewById(getApplication().getResources().getIdentifier("photoView", "id", getApplication().getPackageName()));
+        mAttacher = new PhotoViewAttacher(photo);
 
-	/**
-	 * Get the current Activity
-	 *
-	 * @return
-	 */
-	private Activity getActivity() {
-		return this;
-	}
+        // Title TextView
+        titleTxt = (TextView) findViewById(getApplication().getResources().getIdentifier("titleTxt", "id", getApplication().getPackageName()));
+    }
 
-	/**
-	 * Hide Loading when showing the photo. Update the PhotoView Attacher
-	 */
-	private void hideLoadingAndUpdate() {
-		photo.setVisibility(View.VISIBLE);
-		loadingBar.setVisibility(View.INVISIBLE);
+    /**
+     * Get the current Activity
+     *
+     * @return
+     */
+    private Activity getActivity() {
+        return this;
+    }
+
+    /**
+     * Hide Loading when showing the photo. Update the PhotoView Attacher
+     */
+    private void hideLoadingAndUpdate() {
+        photo.setVisibility(View.VISIBLE);
+        loadingBar.setVisibility(View.INVISIBLE);
         shareBtn.setVisibility(shareBtnVisibility);
 
-		mAttacher.update();
-	}
+        mAttacher.update();
+    }
 
-	/**
-	 * Load the image using Picasso
-	 *
-	 */
-	private void loadImage() {
-		if( mImage.startsWith("http") || mImage.startsWith("file") ) {
-			Picasso.with(this)
-					.load(mImage)
-					.fit()
-					.centerInside()
-					.into(photo, new com.squareup.picasso.Callback() {
-						@Override
-						public void onSuccess() {
-							hideLoadingAndUpdate();
-						}
+    /**
+     * Load the image using Picasso
+     */
+    private void loadImage() {
+        if (mImage.startsWith("http") || mImage.startsWith("file")) {
+            Picasso.with(this)
+                    .load(mImage)
+                    .fit()
+                    .centerInside()
+                    .into(photo, new com.squareup.picasso.Callback() {
+                        @Override
+                        public void onSuccess() {
+                            hideLoadingAndUpdate();
+                        }
 
-						@Override
-						public void onError() {
-							Toast.makeText(getActivity(), "Error loading image.", Toast.LENGTH_LONG).show();
+                        @Override
+                        public void onError() {
+                            Toast.makeText(getActivity(), "Error loading image.", Toast.LENGTH_LONG).show();
 
-							finish();
-						}
-					});
-		} else if ( mImage.startsWith("data:image")){
+                            finish();
+                        }
+                    });
+        } else if (mImage.startsWith("data:image")) {
 
-			new AsyncTask<Void, Void, File>(){
+            new AsyncTask<Void, Void, File>() {
 
-				protected File doInBackground(Void ...params){
-					String base64Image = mImage.substring(mImage.indexOf(",") + 1);
-					File file = null;
-					try{
-						file = getLocalBitmapFile(base64Image);
-					}
-					catch (IOException e){
-						e.printStackTrace();
-					}
-					return file;
-				}
+                protected File doInBackground(Void... params) {
+                    String base64Image = mImage.substring(mImage.indexOf(",") + 1);
+                    return getLocalBitmapFileFromString(base64Image);
+                }
 
-				protected void onPostExecute(File file){
-					mTempImage = file;
-					Picasso.with(PhotoActivity.this)
-						.load(mTempImage)
-						.fit()
-						.centerCrop()
-						.into(photo, new com.squareup.picasso.Callback(){
-							@Override
-							public void onSuccess() {
-								hideLoadingAndUpdate();
-							}
+                protected void onPostExecute(File file) {
+                    mTempImage = file;
+                    Picasso.with(PhotoActivity.this)
+                            .load(mTempImage)
+                            .fit()
+                            .centerCrop()
+                            .into(photo, new com.squareup.picasso.Callback() {
+                                @Override
+                                public void onSuccess() {
+                                    hideLoadingAndUpdate();
+                                }
 
-							@Override
-							public void onError() {
-								Toast.makeText(getActivity(), "Error loading image.", Toast.LENGTH_LONG).show();
+                                @Override
+                                public void onError() {
+                                    Toast.makeText(getActivity(), "Error loading image.", Toast.LENGTH_LONG).show();
 
-								finish();
-							}
-						});
-				}
-			}.execute();
+                                    finish();
+                                }
+                            });
+                }
+            }.execute();
 
         } else {
             photo.setImageURI(Uri.parse(mImage));
 
             hideLoadingAndUpdate();
         }
-	}
+    }
 
-	public void onDestroy(){
-		if (mTempImage != null){
-			mTempImage.delete();
-		}
-		super.onDestroy();
-	}
+    public void onDestroy() {
+        if (mTempImage != null) {
+            mTempImage.delete();
+        }
+        super.onDestroy();
+    }
 
 
-	public File getLocalBitmapFile(String base64) throws IOException{
-		byte []decoded = Base64.decode(base64, Base64.DEFAULT);
-		File file = new File(this.getCacheDir(), "temp_image_" + System.currentTimeMillis() + ".png");
-		file.getParentFile().mkdirs();
-		FileOutputStream output = new FileOutputStream(file);
-		output.write(decoded);
-		output.close();
-		return file;
-	}
+    public File getLocalBitmapFileFromString(String base64) {
+        File file;
+        try {
+            file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                    "share_image_" + System.currentTimeMillis() + ".png");
+            file.getParentFile().mkdirs();
+            FileOutputStream output = new FileOutputStream(file);
+            byte[] decoded = Base64.decode(base64, Base64.DEFAULT);
+            output.write(decoded);
+            output.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            file = null;
+        }
+        return file;
+    }
 
-	/**
-	 * Create Local Image due to Restrictions
-	 *
-	 * @param imageView
-	 *
-	 * @return
-	 */
-	public Uri getLocalBitmapUri(ImageView imageView) {
-		Drawable drawable = imageView.getDrawable();
-		Bitmap bmp = null;
+    /**
+     * Create Local Image due to Restrictions
+     *
+     * @param imageView
+     * @return
+     */
+    public File getLocalBitmapFileFromView(ImageView imageView) {
+        Drawable drawable = imageView.getDrawable();
+        Bitmap bmp;
 
-		if (drawable instanceof BitmapDrawable){
-			bmp = ((BitmapDrawable) imageView.getDrawable()).getBitmap();
-		} else {
-			return null;
-		}
+        if (drawable instanceof BitmapDrawable) {
+            bmp = ((BitmapDrawable) imageView.getDrawable()).getBitmap();
+        } else {
+            return null;
+        }
 
-		// Store image to default external storage directory
-		Uri bmpUri = null;
-		try {
-			File file =  new File(
-					Environment.getExternalStoragePublicDirectory(
-						Environment.DIRECTORY_DOWNLOADS
-					), "share_image_" + System.currentTimeMillis() + ".png");
+        // Store image to default external storage directory
+        File file;
+        try {
+            file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                    "share_image_" + System.currentTimeMillis() + ".png");
+            file.getParentFile().mkdirs();
+            FileOutputStream out = new FileOutputStream(file);
+            bmp.compress(Bitmap.CompressFormat.PNG, 90, out);
+            out.close();
 
-			file.getParentFile().mkdirs();
-
-			FileOutputStream out = new FileOutputStream(file);
-			bmp.compress(Bitmap.CompressFormat.PNG, 90, out);
-			out.close();
-
-			bmpUri = Uri.fromFile(file);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		return bmpUri;
-	}
+        } catch (IOException e) {
+            file = null;
+            e.printStackTrace();
+        }
+        return file;
+    }
 
 }

--- a/src/android/PhotoViewer.java
+++ b/src/android/PhotoViewer.java
@@ -54,13 +54,10 @@ public class PhotoViewer extends CordovaPlugin {
     protected void getPermission() {
         cordova.requestPermissions(this, REQ_CODE, new String[]{WRITE, READ});
     }
-
+//
     protected void launchActivity() throws JSONException {
         Intent i = new Intent(this.cordova.getActivity(), com.sarriaroman.PhotoViewer.PhotoActivity.class);
-
-        i.putExtra("url", this.args.getString(0));
-        i.putExtra("title", this.args.getString(1));
-        i.putExtra("options", this.args.optJSONObject(2).toString());
+        PhotoActivity.mArgs = this.args;
 
         this.cordova.getActivity().startActivity(i);
         this.callbackContext.success("");
@@ -83,4 +80,6 @@ public class PhotoViewer extends CordovaPlugin {
         }
 
     }
+
+
 }

--- a/src/android/PhotoViewer.java
+++ b/src/android/PhotoViewer.java
@@ -13,7 +13,7 @@ import android.content.pm.PackageManager;
 
 /**
  * Class to Open PhotoViewer with the Required Parameters from Cordova
- *
+ * <p>
  * - URL
  * - Title
  */
@@ -39,7 +39,8 @@ public class PhotoViewer extends CordovaPlugin {
             try {
                 JSONObject options = this.args.optJSONObject(2);
                 requiresExternalPermission = options.getBoolean("share");
-            } catch(JSONException exception) { }
+            } catch (JSONException exception) {
+            }
 
             if (!requiresExternalPermission || (cordova.hasPermission(READ) && cordova.hasPermission(WRITE))) {
                 this.launchActivity();
@@ -54,7 +55,8 @@ public class PhotoViewer extends CordovaPlugin {
     protected void getPermission() {
         cordova.requestPermissions(this, REQ_CODE, new String[]{WRITE, READ});
     }
-//
+
+    //
     protected void launchActivity() throws JSONException {
         Intent i = new Intent(this.cordova.getActivity(), com.sarriaroman.PhotoViewer.PhotoActivity.class);
         PhotoActivity.mArgs = this.args;
@@ -66,14 +68,14 @@ public class PhotoViewer extends CordovaPlugin {
     @Override
     public void onRequestPermissionResult(int requestCode, String[] permissions,
                                           int[] grantResults) throws JSONException {
-        for(int r:grantResults) {
-            if(r == PackageManager.PERMISSION_DENIED) {
+        for (int r : grantResults) {
+            if (r == PackageManager.PERMISSION_DENIED) {
                 this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, PERMISSION_DENIED_ERROR));
                 return;
             }
         }
 
-        switch(requestCode) {
+        switch (requestCode) {
             case REQ_CODE:
                 launchActivity();
                 break;


### PR DESCRIPTION
Cuando se pasa una imagen en base 64, ésta puede ser muy grande como para pasar a través del método putExtra del Intent lo que ocasiona un [error en ejecución](https://www.neotechsoftware.com/blog/android-intent-size-limit). También agregué algo de código para que la carga de la imagen en base64 se hiciera en un thread aparte y la imagen guardada para compartir se eliminara al destruir el activity