### PR TITLE
Removed crop from base64 images

### DIFF
--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -192,7 +192,7 @@ public class PhotoActivity extends Activity {
                     Picasso.with(PhotoActivity.this)
                             .load(mTempImage)
                             .fit()
-                            .centerCrop()
+                            .centerInside()
                             .into(photo, new com.squareup.picasso.Callback() {
                                 @Override
                                 public void onSuccess() {


### PR DESCRIPTION
Hi there!
I'm developing application, where I need to show large image, that comes from pouchdb and I use photoviewer for that by passing base64 data. The problem I have is that image get always cropped vertically in portrait mode, and even user tries to zoom it out, he can't see some regions to the left and right sides of image.
Seems that this issue was already reported here: https://github.com/sarriaroman/photoviewer/issues/143

PR contains simple fix, that worked for me. From other discussions I understood that this line was placed to fix OOM issues on android, but I haven't seen any while was testing it.