### PR TITLE
HTTP header support

### DIFF
--- a/src/ios/PhotoViewer.m
+++ b/src/ios/PhotoViewer.m
@@ -77,7 +77,7 @@
         BOOL isShareEnabled = [[command.arguments objectAtIndex:2] boolValue];
         showCloseBtn = [[command.arguments objectAtIndex:3] boolValue];
         copyToReference = [[command.arguments objectAtIndex:4] boolValue];
-        headers = [self headers:[command objectAtIndex:5]];
+        headers = [self headers:[command.arguments objectAtIndex:5]];
         
         if ([url rangeOfString:@"http"].location == 0) {
             copyToReference = true;

--- a/www/PhotoViewer.js
+++ b/www/PhotoViewer.js
@@ -21,7 +21,11 @@ exports.show = function(url, title, options) {
         options.copyToReference = false;
     }
 
-    var args = [url, title, options.share, options.closeButton, options.copyToReference];
+    if (options.headers === undefined) {
+        options.headers = '';
+    }
+
+    var args = [url, title, options.share, options.closeButton, options.copyToReference, options.headers];
 
     exec(function() {}, function() {}, "PhotoViewer", "show", args);
 };


### PR DESCRIPTION
Roman,
I have add HTTP header support for iOS and Android.  I tried to modify as little as possible and it is non-contract breaking.  I added a new option called "headers" that takes a JSON string of header key/value pairs.  For example in my tests with a JWT token for authorization using your example:

```
var options = {
    share: true, // default is false
    closeButton: false, // default is true
    copyToReference: true // default is false
    headers: '{"Authorization":"Bearer eyJ0eXAiOiJKV1QiLC..."}' // default is no headers
};

PhotoViewer.show('http://my_authenticated_site.com/my_image.jpg', 'Optional Title', options);
```

BUT, and this is a big but, I have no idea how to actually test this in a Cordova environment.  

Instead, for iOS I created a small single-page-view iOS sample app and had the ViewController use the PhotoViewer.m file the same way I believe Cordova is using it.  The code was very straight-forward:

```
@implementation ViewController

- (void)viewDidLoad {
    [super viewDidLoad];
    PhotoViewer *photoViewer = [PhotoViewer alloc];
    NSString *title = @"TITLE";
    NSString *urlString = [NSString stringWithFormat:@"http://localhost:8080/service/v1/documents/%d/page/%d/show", 580, 1];
    NSString *token = @"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzUxMiJ9.eyJpc3MiOiJhdXRoMCIsIm5hbWUiOiJCdWdzIEJ1bm55IiwiZXhwaXJlQXRFcG9jaE1pbGxpcyI6MTU0NjM5NzE2MzUwNiwicHJvZ3JhbXMiOls1Ml0sInVzZXJUeXBlIjoxLCJpZCI6NjksImV4cCI6MTU0NjM5NzE2M30.rlXiBSvnl3WZOq2vpvnBNWYZKupJU78d1h7EZpXscbJBbueV3rJjML4H00fggHiLejnxEqyj7QLCtOf3dmlYiW3cVjxS_jsvkHlqeM8QM95jR4EatDtVV3bQXflq_QE_y2fL8A-kDxyz3IEbEHMYzn9tO-bdWhbN_QvimoSMuMbH9ogRmZkjxp5ru5avwxCMfi_nngi7bZgyLSm7FtQtfHLzI4jB4fq0z2ForsAI3KWJIYDi2Kq2fGYVi9x_0TKtFvQzWpA-JIAGTtN_jbNlOM8vPF7oCf9_sSSI9wb702tcwf1d-zfOraCLQXsrp4QEYd5JY6rIU8u401FvEVnnrg";
    NSString *headerString = [NSString stringWithFormat:@"{\"Authorization\":\"Bearer %@\"}", token];
    NSArray *parameters = [NSArray arrayWithObjects:urlString, title, @"false", @"false", @"false", headerString, nil];
    photoViewer.viewController = self;
    [photoViewer show:parameters];
}

@end
```

And for Android I created a single Activity app where the MainActivity calls the PhotoActivity.java:
```
    @Override
    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);

        JSONArray args = new JSONArray();
        String token = "eyJ0eXAiOiJKV1QiLC...";
        args.put("http://api.documentsentry.com/service/v1/documents/580/page/1/show");
        args.put("TITLE");
        args.put("true");
        args.put("true");
        args.put("true");
        args.put("{\"Authorization\":\"Bearer " + token + "\"}");

        Intent i = new Intent(this, com.example.smelzer.photoviewertestharness.PhotoActivity.class);
        PhotoActivity.mArgs = args;

        this.startActivity(i);
    }
```

I tried many variations of the parameters with both insecure and secure URLs and different options (I removed all the combinations from the sample above for readability).  Everything appears to work as expected, at least from my test harnesses.  If you want me to test further from Cordova I will need some help understanding how to actually do it.

Let me know what you think.

Thanks,
Steve