### PR TITLE
Prevent Android devices from crashing when options is not well structured

### DIFF
--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -71,8 +71,15 @@ public class PhotoActivity extends Activity {
             this.mImage = mArgs.getString(0);
             this.mTitle = mArgs.getString(1);
             this.mShare = mArgs.getBoolean(2);
-            this.mHeaders = parseHeaders(mArgs.getString(5));
-            this.pOptions = mArgs.getJSONObject(6);
+            this.mHeaders = parseHeaders(mArgs.optString(5));
+            this.pOptions = mArgs.optJSONObject(6);
+
+            if( pOptions == null ) {
+                pOptions = new JSONObject();
+                pOptions.put("fit", true);
+                pOptions.put("centerInside", true);
+                pOptions.put("centerCrop", false);
+            }
 
             //Set the share button visibility
             shareBtnVisibility = this.mShare ? View.VISIBLE : View.INVISIBLE;


### PR DESCRIPTION
Prevent Android devices from crashing when options is not well structured.

Not well structured options can be passed simply:
```
photoViewer.show(url, "title", {share: true})
```
PhotoViewer.js shows this. Well structured options are passed only when user does not specify options at all:
```
var PhotoViewer = /** @class */ (function () {
    function PhotoViewer() {
    }
    PhotoViewer.show = function (url, title, options) {
        if (title === void 0) { title = ''; }
        if (options === void 0) { options = {
            share: false,
            closeButton: true,
            copyToReference: false,
            headers: '',
            piccasoOptions: {
                fit: true,
                centerInside: true,
                centerCrop: false
            }
        }; }
        if (url && url.trim() == '') {
            // Do nothing
            return;
        }
        var args = [url, title, options.share, options.closeButton, options.copyToReference, options.headers, options.piccasoOptions];
        exec(function () { }, function () { }, "PhotoViewer", "show", args);
    };
    return PhotoViewer;
}());
```
In other case PhotoActivity.java gives wrong options.