### PR TITLE
Replaced compile with implementation for gradle 7

### DIFF
--- a/src/android/photoviewer.gradle
+++ b/src/android/photoviewer.gradle
@@ -3,8 +3,8 @@ repositories{
 }
 
 dependencies {
-   compile 'com.commit451:PhotoView:1.2.4'
-   compile 'com.squareup.picasso:picasso:2.71828'
+   implementation 'com.commit451:PhotoView:1.2.4'
+   implementation 'com.squareup.picasso:picasso:2.71828'
 }
 
 android {


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It is removed in version 7.0 of the Android Gradle plugin and has been deprecated since gradle 4.10.
For more information, see http://d.android.com/r/tools/update-dependency-configurations.html. and https://stackoverflow.com/a/66910991/5404159