### PR TITLE
Auto rotate image on device rotation on iOS

### DIFF
--- a/src/ios/PhotoViewer.m
+++ b/src/ios/PhotoViewer.m
@@ -287,13 +287,15 @@
     if(fullView != nil) {
         double newRotation = [self getRotation];
    
-        if(currentRotation) {
-            imageView.transform = CGAffineTransformMakeRotation(-(currentRotation * M_PI / 180));
-        }
+        if(newRotation >= 0.0) {
+            if(currentRotation) {
+                imageView.transform = CGAffineTransformMakeRotation(-(currentRotation * M_PI / 180));
+            }
 
-        imageView.transform = CGAffineTransformMakeRotation(newRotation * M_PI / 180);
-        
-        currentRotation = newRotation;
+            imageView.transform = CGAffineTransformMakeRotation(newRotation * M_PI / 180);
+            
+            currentRotation = newRotation;
+        }
         
         CGFloat viewWidth = self.viewController.view.bounds.size.width;
         CGFloat viewHeight = self.viewController.view.bounds.size.height;
@@ -306,7 +308,7 @@
 }
 
 - (double) getRotation
-{
+{    
     switch([[UIDevice currentDevice] orientation]) {
         case UIDeviceOrientationPortraitUpsideDown:
             return 180.0;
@@ -317,11 +319,11 @@
         case UIDeviceOrientationLandscapeRight:
             return 270.0;
             break;
-        
-        case UIDeviceOrientationUnknown:
         case UIDeviceOrientationPortrait:
-        default:
             return 0.0;
+        case UIDeviceOrientationUnknown:
+        default:
+            return -1.0;
             break;
     }
 }

--- a/src/ios/PhotoViewer.m
+++ b/src/ios/PhotoViewer.m
@@ -15,6 +15,7 @@
     BOOL showCloseBtn;
     BOOL copyToReference;
     NSDictionary *headers;
+    double currentRotation;
 }
 
 @property (nonatomic, strong) UIDocumentInteractionController *docInteractionController;
@@ -57,6 +58,9 @@
 - (void)show:(CDVInvokedUrlCommand*)command
 {
     if (isOpen == false) {
+
+        currentRotation = [self getRotation];
+        
         [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(orientationChanged:)
@@ -279,7 +283,18 @@
 
 - (void) orientationChanged:(NSNotification *)note
 {
+    
     if(fullView != nil) {
+        double newRotation = [self getRotation];
+   
+        if(currentRotation) {
+            imageView.transform = CGAffineTransformMakeRotation(-(currentRotation * M_PI / 180));
+        }
+
+        imageView.transform = CGAffineTransformMakeRotation(newRotation * M_PI / 180);
+        
+        currentRotation = newRotation;
+        
         CGFloat viewWidth = self.viewController.view.bounds.size.width;
         CGFloat viewHeight = self.viewController.view.bounds.size.height;
 
@@ -287,6 +302,27 @@
         [imageView setFrame:CGRectMake(0, 0, viewWidth, viewHeight)];
         fullView.contentSize = imageView.frame.size;
         [closeBtn setFrame:CGRectMake(0, viewHeight - 50, 50, 50)];
+    }
+}
+
+- (double) getRotation
+{
+    switch([[UIDevice currentDevice] orientation]) {
+        case UIDeviceOrientationPortraitUpsideDown:
+            return 180.0;
+            break;
+        case UIDeviceOrientationLandscapeLeft:
+            return 90.0;
+            break;
+        case UIDeviceOrientationLandscapeRight:
+            return 270.0;
+            break;
+        
+        case UIDeviceOrientationUnknown:
+        case UIDeviceOrientationPortrait:
+        default:
+            return 0.0;
+            break;
     }
 }
 
@@ -318,3 +354,4 @@
 }
 
 @end
+


### PR DESCRIPTION
Add support for rotation the image when rotating an iOS device.
This functionality is already present on Android.