### PR TITLE
Fixes mArgs beeing null on recreation of activity

### DIFF
--- a/src/android/PhotoActivity.java
+++ b/src/android/PhotoActivity.java
@@ -52,8 +52,6 @@ public class PhotoActivity extends Activity {
     private File mTempImage;
     private int shareBtnVisibility;
 
-    public static JSONArray mArgs = null;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -64,6 +62,7 @@ public class PhotoActivity extends Activity {
         findViews();
 
         try {
+			JSONArray mArgs = new JSONArray(getIntent().getStringExtra("ARGS"));
             this.mImage = mArgs.getString(0);
             this.mTitle = mArgs.getString(1);
             this.mShare = mArgs.getBoolean(2);

--- a/src/android/PhotoViewer.java
+++ b/src/android/PhotoViewer.java
@@ -51,7 +51,7 @@ public class PhotoViewer extends CordovaPlugin {
     //
     protected void launchActivity() throws JSONException {
         Intent i = new Intent(this.cordova.getActivity(), com.sarriaroman.PhotoViewer.PhotoActivity.class);
-        PhotoActivity.mArgs = this.args;
+		i.putExtra("ARGS", this.args.toString());
 
         this.cordova.getActivity().startActivity(i);
         this.callbackContext.success("");


### PR DESCRIPTION
This is an attempt to fix issues where mArgs is null, and causes a crash in the plug-in.

Im suspecting its because sometimes the intent is being recreated by the OS, to save power/memory, and then mArgs isn't being set, because the intent/activity is not created from the photoviewer.

I changed it so the values are passed using putExtra instead, which seems to be the official way to solve this