### PR TITLE
Android 13 permissions fix

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,9 @@
 
 		<config-file parent="/manifest" target="AndroidManifest.xml">
 			<uses-permission android:name="android.permission.INTERNET" />
-			<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-			<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+			<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+			<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+      <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33" />
 		</config-file>
 
 		<source-file src="src/android/PhotoViewer.java" target-dir="src/com/sarriaroman/PhotoViewer" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,8 @@
 
 		<config-file parent="/manifest" target="AndroidManifest.xml">
 			<uses-permission android:name="android.permission.INTERNET" />
-			<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-			<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+			<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+			<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
       <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33" />
 		</config-file>
 

--- a/src/android/PhotoViewer.java
+++ b/src/android/PhotoViewer.java
@@ -23,8 +23,6 @@ public class PhotoViewer extends CordovaPlugin {
     public static final String WRITE = Manifest.permission.WRITE_EXTERNAL_STORAGE;
     public static final String READ = Manifest.permission.READ_EXTERNAL_STORAGE;
     public static final String READ_IMAGES = Manifest.permission.READ_MEDIA_IMAGES;
-    public static final String READ_VIDEO = Manifest.permission.READ_MEDIA_VIDEO;
-    public static final String READ_AUDIO = Manifest.permission.READ_MEDIA_AUDIO;
 
     public static final int REQ_CODE = 0;
 
@@ -37,7 +35,7 @@ public class PhotoViewer extends CordovaPlugin {
             this.args = args;
             this.callbackContext = callbackContext;
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                if (cordova.hasPermission(READ_IMAGES) && cordova.hasPermission(READ_VIDEO) && cordova.hasPermission(READ_AUDIO)) {
+                if (cordova.hasPermission(READ_IMAGES)) {
                     this.launchActivity();
                 } else {
                     this.getPermission();
@@ -56,7 +54,7 @@ public class PhotoViewer extends CordovaPlugin {
 
     protected void getPermission() {
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            cordova.requestPermissions(this, REQ_CODE, new String[]{READ_IMAGES, READ_VIDEO, READ_AUDIO});
+            cordova.requestPermissions(this, REQ_CODE, new String[]{READ_IMAGES});
         } else {
             cordova.requestPermissions(this, REQ_CODE, new String[]{WRITE, READ});
         }

--- a/src/android/PhotoViewer.java
+++ b/src/android/PhotoViewer.java
@@ -22,6 +22,9 @@ public class PhotoViewer extends CordovaPlugin {
 
     public static final String WRITE = Manifest.permission.WRITE_EXTERNAL_STORAGE;
     public static final String READ = Manifest.permission.READ_EXTERNAL_STORAGE;
+    public static final String READ_IMAGES = Manifest.permission.READ_MEDIA_IMAGES;
+    public static final String READ_VIDEO = Manifest.permission.READ_MEDIA_VIDEO;
+    public static final String READ_AUDIO = Manifest.permission.READ_MEDIA_AUDIO;
 
     public static final int REQ_CODE = 0;
 
@@ -33,11 +36,18 @@ public class PhotoViewer extends CordovaPlugin {
         if (action.equals("show")) {
             this.args = args;
             this.callbackContext = callbackContext;
-
-            if (cordova.hasPermission(READ) && cordova.hasPermission(WRITE)) {
-                this.launchActivity();
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                if (cordova.hasPermission(READ_IMAGES) && cordova.hasPermission(READ_VIDEO) && cordova.hasPermission(READ_AUDIO)) {
+                    this.launchActivity();
+                } else {
+                    this.getPermission();
+                }
             } else {
-                this.getPermission();
+                if (cordova.hasPermission(READ) && cordova.hasPermission(WRITE)) {
+                    this.launchActivity();
+                } else {
+                    this.getPermission();
+                }
             }
             return true;
         }
@@ -45,7 +55,11 @@ public class PhotoViewer extends CordovaPlugin {
     }
 
     protected void getPermission() {
-        cordova.requestPermissions(this, REQ_CODE, new String[]{WRITE, READ});
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            cordova.requestPermissions(this, REQ_CODE, new String[]{READ_IMAGES, READ_VIDEO, READ_AUDIO});
+        } else {
+            cordova.requestPermissions(this, REQ_CODE, new String[]{WRITE, READ});
+        }
     }
 
     //

--- a/src/android/PhotoViewer.java
+++ b/src/android/PhotoViewer.java
@@ -3,6 +3,7 @@ package com.sarriaroman.PhotoViewer;
 import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;


### PR DESCRIPTION
Fixed the problem with viewing files on Android 13 devices.
Have tested the fix on Tab Active 3s. One of them on Android 13, the other one on Android 12. Both preview files correctly.
This was tested as a plugin on an ionic capacitor app deployed to Android Studio Flamingo 2022.2.1 Patch 2.